### PR TITLE
Python and OCIO support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,27 @@ FROM aswf/ci-base:2023.1 as build-stage
 RUN alias ll='ls -hl'
 RUN yum update -y && yum install tree -y
 
+# TODO: move to separate config file
+# Notes on variable names:
+# PYENV_VERSION is reserved by pyenv for python version to use
+# PYTHON_VERSION is reserved by pybind11 for python version to build for (set latter)
+
 # for pyenv
+ARG PYTHON_PYENV_VERSION=2.3.31
 ARG PYTHON_VERSION_FULL=3.9.10
 # for pybind11
 ARG PYTHON_VERSION_SHORT=3.9
 
+# Dependency Versions
+ARG LIBJPEGTURBO_VERSION=3.0.0
+ARG LIBTIFF_VERION=4.0.10
+ARG LIBRAW_VERSION=0.21.1
+ARG ZLIB_VERSION=1.3
+ARG PYBIND11_VERSION=2.11.1
+ARG BOOST_VERSION=1_81_0
+ARG OPENEXR_VERSION=2.4.15.0
+ARG OPENCOLORIO_VERSION=2.3.0
+ARG OPENIMAGEIO_VESION=2.4.15.0
 # In order not to depend on the outer internet, this Dockerfile tries to only
 # rely on local files. This means that before running it, you will need to
 # have downloaded all of the tarballs required to compile the various
@@ -23,17 +39,16 @@ COPY tarballs ${TARBALLS_ROOT}
 # Compile ZLIB
 ARG ZLIB_ROOT=/opt/zlib
 WORKDIR ${ZLIB_ROOT}
-RUN cp ${TARBALLS_ROOT}/zlib-1.3.tar.gz . \
-    && tar -xvf zlib-1.3.tar.gz \
-    && cd zlib-1.3 \
+RUN cp ${TARBALLS_ROOT}/zlib-${ZLIB_VERSION}.tar.gz . \
+    && tar -xvf zlib-${ZLIB_VERSION}.tar.gz \
+    && cd zlib-${ZLIB_VERSION} \
     && cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${ZLIB_ROOT} \
     && cmake --build build --config Release --target install
 
 # Compile OpenEXR
 ARG OPENEXR_ROOT=/opt/openexr
 WORKDIR ${OPENEXR_ROOT}
-
-RUN cp ${TARBALLS_ROOT}/OpenEXR_v2.4.15.0.tar.gz . \
+RUN cp ${TARBALLS_ROOT}/OpenEXR_v${OPENEXR_VERSION}.tar.gz . \
     && tar -xvf OpenEXR_* \
     && mv openexr-*/* . \
     && mv openexr-*/.[!.]* .
@@ -45,9 +60,9 @@ RUN cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${OPEN
 # Compile Boost
 ARG BOOST_ROOT=/opt/boost
 WORKDIR ${BOOST_ROOT}/download
-RUN cp ${TARBALLS_ROOT}/boost_1_81_0.tar.bz2 . \
-    && tar --bzip2 -xvf boost_1_81_0.tar.bz2
-RUN cd boost_1_81_0 \
+RUN cp ${TARBALLS_ROOT}/boost_${BOOST_VERSION}.tar.bz2 . \
+    && tar --bzip2 -xvf boost_${BOOST_VERSION}.tar.bz2
+RUN cd boost_${BOOST_VERSION} \
     && ./bootstrap.sh --prefix=${BOOST_ROOT} \
     && ./b2 install \
     && rm -rf ${BOOST_ROOT}/download
@@ -55,9 +70,9 @@ RUN cd boost_1_81_0 \
 # libtiff
 ARG TIFF_ROOT=/opt/tiff
 WORKDIR ${TIFF_ROOT}/download
-RUN cp ${TARBALLS_ROOT}/tiff-4.0.10.tar.gz . \
-    && tar -xvf tiff-4.0.10.tar.gz
-RUN cd tiff-4.0.10 \
+RUN cp ${TARBALLS_ROOT}/tiff-${LIBTIFF_VERION}.tar.gz . \
+    && tar -xvf tiff-${LIBTIFF_VERION}.tar.gz
+RUN cd tiff-${LIBTIFF_VERION} \
     && ./configure --prefix=${TIFF_ROOT} \
     && cmake -S . -B build \
     -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=${TIFF_ROOT} \
@@ -68,9 +83,9 @@ RUN cd tiff-4.0.10 \
 # libraw
 ARG LIBRAW_ROOT=/opt/libraw
 WORKDIR ${LIBRAW_ROOT}/download
-RUN cp ${TARBALLS_ROOT}/LibRaw-0.21.1.tar.gz . \
-    && tar -xvf LibRaw-0.21.1.tar.gz
-RUN cd LibRaw-0.21.1 \
+RUN cp ${TARBALLS_ROOT}/LibRaw-${LIBRAW_VERSION}.tar.gz . \
+    && tar -xvf LibRaw-${LIBRAW_VERSION}.tar.gz
+RUN cd LibRaw-${LIBRAW_VERSION} \
     && autoreconf -fiv \
     && ./configure --prefix /opt/libraw \
     && make install \
@@ -78,68 +93,82 @@ RUN cd LibRaw-0.21.1 \
 
 # OpenColorIO tar build
 ARG OpenColorIO_ROOT=/opt/OpenColorIO
-ARG OpenColorIO_BUILD_ROOT=/opt/OpenColorIO/dist
-ARG OPENCOLORIO_BUILDOPTS="-DOCIO_BUILD_APPS=OFF -DOCIO_BUILD_NUKE=OFF \
-                           -DOCIO_BUILD_DOCS=OFF -DOCIO_BUILD_TESTS=OFF \
-                           -DOCIO_BUILD_GPU_TESTS=OFF \
-                           -DOCIO_BUILD_PYTHON=OFF -DOCIO_BUILD_PYGLUE=OFF \
-                           -DOCIO_BUILD_JAVA=OFF \
-                           -DBUILD_SHARED_LIBS=ON"
+ARG OpenColorIO_INSTALL_DIR=${OpenColorIO_ROOT}/dist
 WORKDIR ${OpenColorIO_ROOT}
-RUN cp ${TARBALLS_ROOT}/OpenColorIO_v2.3.0.tar.gz . \
-    && tar -xvf OpenColorIO_v2.3.0.tar.gz
-RUN cd OpenColorIO-2.3.0 \
+RUN cp ${TARBALLS_ROOT}/OpenColorIO_v${OPENCOLORIO_VERSION}.tar.gz . \
+    && tar -xvf OpenColorIO_v${OPENCOLORIO_VERSION}.tar.gz
+RUN cd OpenColorIO-${OPENCOLORIO_VERSION} \
     && mkdir build \
     && cd build \
     && cmake -DCMAKE_BUILD_TYPE=Release \
-           -DCMAKE_INSTALL_PREFIX=${OpenColorIO_BUILD_ROOT} \
-           -DCMAKE_CXX_FLAGS="-Wno-unused-function -Wno-deprecated-declarations -Wno-cast-qual -Wno-write-strings" \
-           ${OPENCOLORIO_BUILDOPTS} ${OpenColorIO_ROOT}/OpenColorIO-2.3.0 \
+             -DCMAKE_INSTALL_PREFIX=${OpenColorIO_INSTALL_DIR} \
+             -DCMAKE_CXX_FLAGS="-Wno-unused-function -Wno-deprecated-declarations -Wno-cast-qual -Wno-write-strings" \
+             -DOCIO_BUILD_APPS=OFF -DOCIO_BUILD_NUKE=OFF \
+             -DOCIO_BUILD_DOCS=OFF -DOCIO_BUILD_TESTS=OFF \
+             -DOCIO_BUILD_GPU_TESTS=OFF \
+             -DOCIO_BUILD_PYTHON=OFF -DOCIO_BUILD_PYGLUE=OFF \
+             -DOCIO_BUILD_JAVA=OFF \
+             -DBUILD_SHARED_LIBS=ON \
+             .. \
     && cmake --build . --config Release --target install
 # Fix weird syntax error that occurs from build
-RUN sed -i "s;.\#define ZLIB_VERSION \"1.3\"; ;g" ${OpenColorIO_BUILD_ROOT}/lib64/cmake/OpenColorIO/OpenColorIOConfig.cmake
+# Uncertain if $ZLIB_VERSION will match the version OCIO uses. Originally the OCIO build here uses 1.3
+RUN sed -i "s;.\#define ZLIB_VERSION \"${ZLIB_VERSION}\"; ;g" ${OpenColorIO_INSTALL_DIR}/lib64/cmake/OpenColorIO/OpenColorIOConfig.cmake
 
 
 # Install specific python
-ENV PYENV_ROOT=/opt/pyenv
-RUN git clone https://github.com/pyenv/pyenv.git ${PYENV_ROOT}
+ARG PYENV_BASE_DIR=/opt/pyenv
+WORKDIR ${PYENV_BASE_DIR}
+RUN cp ${TARBALLS_ROOT}/pyenv-${PYTHON_PYENV_VERSION}.tar.gz . \
+    && tar -xvf pyenv-${PYTHON_PYENV_VERSION}.tar.gz \
+    && mkdir pyenv-${PYTHON_PYENV_VERSION}/cache \
+    && cp ${TARBALLS_ROOT}/Python-${PYTHON_VERSION_FULL}.tar.xz pyenv-${PYTHON_PYENV_VERSION}/cache/
+ENV PYENV_ROOT=${PYENV_BASE_DIR}/pyenv-${PYTHON_PYENV_VERSION}
+# python versions are defined per pyenv
 ENV PATH ${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}
-
 RUN pyenv install ${PYTHON_VERSION_FULL}
 RUN pyenv global ${PYTHON_VERSION_FULL}
 RUN pyenv rehash
 
-ARG OIIO_ROOT=/opt/OpenImageIO
-WORKDIR ${OIIO_ROOT}
-
-RUN cp ${TARBALLS_ROOT}/OpenImageIO_v2.4.15.0.tar.gz . \
-    && tar -xvf OpenImageIO_v2.4.15.0.tar.gz
-WORKDIR ${OIIO_ROOT}/OpenImageIO-2.4.15.0
-
 # Compile libjpeg-turbo
-# TODO: Use a tarball here too
-# https://github.com/libjpeg-turbo/libjpeg-turbo/blob/main/BUILDING.md
-ARG JPEGTurbo_ROOT=/opt/OpenImageIO/OpenImageIO-2.4.15.0/src/build-scripts/ext/dist
-RUN cd src/build-scripts \
-    && ./build_libjpeg-turbo.bash
-
-# Compile OpenColorIO
-#ARG OpenColorIO_ROOT=/opt/OpenImageIO/OpenImageIO-2.4.15.0/src/build-scripts/ext/dist
-#RUN cd src/build-scripts \
-#    && ./build_opencolorio.bash
-# Fix weird syntax error that occurs from build
-#RUN sed -i "s;.\#define ZLIB_VERSION \"1.3\"; ;g" ${OpenColorIO_ROOT}/lib64/cmake/OpenColorIO/OpenColorIOConfig.cmake
+ARG JPEGTurbo_ROOT=/opt/libjpeg-turbo
+ARG LIBJPEGTURBO_INSTALL_DIR=${JPEGTurbo_ROOT}/dist
+WORKDIR ${JPEGTurbo_ROOT}
+RUN cp ${TARBALLS_ROOT}/libjpeg-turbo_v${LIBJPEGTURBO_VERSION}.tar.gz . \
+    && tar -xvf libjpeg-*
+RUN cd libjpeg-turbo-${LIBJPEGTURBO_VERSION} \
+    && mkdir build \
+    && cd build \
+    && cmake -DCMAKE_BUILD_TYPE=Release \
+             -DCMAKE_INSTALL_PREFIX=${LIBJPEGTURBO_INSTALL_DIR} \
+             .. \
+    && cmake --build . --config Release --target install
 
 # Compile pybind11
 ENV PYBIND11_PYTHON_VERSION ${PYTHON_VERSION_SHORT}
 ENV PYTHON_VERSION ${PYTHON_VERSION_SHORT}
-
-RUN cd src/build-scripts \
-    && ./build_pybind11.bash
+ARG PYBIND11_ROOT=/opt/pybind11
+ARG PYBIND11_INSTALL_DIR=/opt/pybind11/dist
+WORKDIR ${PYBIND11_ROOT}
+RUN cp ${TARBALLS_ROOT}/pybind11-${PYBIND11_VERSION}.tar.gz . \
+    && tree -L 2 -d \
+    && tar -xvf pybind11-*
+RUN  cd pybind11-${PYBIND11_VERSION} \
+    && mkdir build \
+    && cd build \
+    && cmake -DCMAKE_BUILD_TYPE=Release \
+             -DCMAKE_INSTALL_PREFIX=${PYBIND11_INSTALL_DIR} \
+             -DPYBIND11_TEST=OFF \
+             -DPYBIND11_PYTHON_VERSION=${PYTHON_VERSION}  \
+             .. \
+    && cmake --build . --config Release --target install
 
 # Copy and compile OpenImageIO
-RUN which python \
-    pwd \
+ARG OIIO_ROOT=/opt/OpenImageIO
+WORKDIR ${OIIO_ROOT}
+RUN cp ${TARBALLS_ROOT}/OpenImageIO_v${OPENIMAGEIO_VESION}.tar.gz . \
+    && tar -xvf OpenImageIO_v${OPENIMAGEIO_VESION}.tar.gz
+RUN cd OpenImageIO-${OPENIMAGEIO_VESION} \
     && tree -L 2 -d \
     && make -j $(nproc) USE_PYTHON=1 USE_TBB=0 USE_NUKE=0 BUILD_SHARED_LIBS=1 USE_QT=0 \
     Boost_ROOT=${BOOST_ROOT} \
@@ -147,8 +176,8 @@ RUN which python \
     LibRaw_ROOT=${LIBRAW_ROOT} \
     TIFF_ROOT=${TIFF_ROOT} \
     OpenEXR_ROOT=${OPENEXR_ROOT}/dist \
-    OpenColorIO_ROOT=${OpenColorIO_BUILD_ROOT} \
-    JPEGTurbo_ROOT=${JPEGTurbo_ROOT} \
+    OpenColorIO_ROOT=${OpenColorIO_INSTALL_DIR} \
+    JPEGTurbo_ROOT=${LIBJPEGTURBO_INSTALL_DIR} \
     Imath_DIR=${OPENEXR_ROOT}/dist/lib64/cmake/Imath
 
 # Create a tarball of the OIIO build
@@ -161,17 +190,17 @@ RUN yum install patchelf -y
 
 # Copy all the .so files needed by OIIO, except for the ones
 # that should be installed on the system (so in /usr and /lib)
-RUN ldd ${OIIO_ROOT}/OpenImageIO-2.4.15.0/dist/lib64/libOpenImageIO.so \
+RUN ldd ${OIIO_ROOT}/OpenImageIO-${OPENIMAGEIO_VESION}/dist/lib64/libOpenImageIO.so \
     | awk '{ print $3 }' | tr -s '\n' \
     | grep '/opt' \
     > libs_to_copy.txt \
     && mkdir third-party-libs \
     && xargs -a libs_to_copy.txt cp -t third-party-libs \
-    && cp ${OIIO_ROOT}/OpenImageIO-2.4.15.0/src/build-scripts/ext/dist/lib64/*.so.* third-party-libs
+    && cp ${LIBJPEGTURBO_INSTALL_DIR}/lib64/*.so.* third-party-libs
 
 # Flatten all of the libs into the lib64 directory
 # and patch their RPATH
-RUN cp -r ${OIIO_ROOT}/OpenImageIO-2.4.15.0/dist . \
+RUN cp -r ${OIIO_ROOT}/OpenImageIO-${OPENIMAGEIO_VESION}/dist . \
     && mv third-party-libs/* dist/lib64 \
     && rm -rf dist/lib64/cmake \
     && rm -rf dist/lib64/pkgconfig \

--- a/download_tarballs.sh
+++ b/download_tarballs.sh
@@ -19,5 +19,7 @@ cd tarballs
 [ ! -f OpenEXR_v2.4.15.0.tar.gz ] && wget https://github.com/AcademySoftwareFoundation/openexr/archive/refs/tags/v3.2.1.tar.gz -O OpenEXR_v2.4.15.0.tar.gz
 # OpenImageIO
 [ ! -f OpenImageIO_v2.4.15.0.tar.gz ] && wget https://github.com/AcademySoftwareFoundation/OpenImageIO/archive/refs/tags/v2.4.15.0.tar.gz -O OpenImageIO_v2.4.15.0.tar.gz
+# OpenColorIO
+[ ! -f OpenColorIO_v2.3.0.tar.gz ] && wget https://github.com/AcademySoftwareFoundation/OpenColorIO/archive/refs/tags/v2.3.0.tar.gz -O OpenColorIO_v2.3.0.tar.gz
 # Zlib
 [ ! -f zlib-1.3.tar.gz ] && wget https://github.com/madler/zlib/releases/download/v1.3/zlib-1.3.tar.gz

--- a/download_tarballs.sh
+++ b/download_tarballs.sh
@@ -6,6 +6,7 @@ mkdir -p tarballs
 cd tarballs
 
 # TODO: add sha256 checks for every tarball
+# TODO: add tarball support for fmtlib & Tessil (downloaded automatically by OIIO)
 
 # Boost
 [ ! -f boost_1_81_0.tar.bz2 ] && wget https://boostorg.jfrog.io/artifactory/main/release/1.81.0/source/boost_1_81_0.tar.bz2
@@ -23,3 +24,11 @@ cd tarballs
 [ ! -f OpenColorIO_v2.3.0.tar.gz ] && wget https://github.com/AcademySoftwareFoundation/OpenColorIO/archive/refs/tags/v2.3.0.tar.gz -O OpenColorIO_v2.3.0.tar.gz
 # Zlib
 [ ! -f zlib-1.3.tar.gz ] && wget https://github.com/madler/zlib/releases/download/v1.3/zlib-1.3.tar.gz
+# pybind11
+[ ! -f pybind11-2.11.1.tar.gz ] && wget https://github.com/pybind/pybind11/archive/refs/tags/v2.11.1.tar.gz -O pybind11-2.11.1.tar.gz
+# pyenv
+[ ! -f pyenv-2.3.31.tar.gz ] && wget https://github.com/pyenv/pyenv/archive/refs/tags/v2.3.31.tar.gz -O pyenv-2.3.31.tar.gz
+# python for pyenv
+# Make sure the downloaded version of pyenv supports the downloaded version of python.
+[ ! -f Python-3.9.10.tar.xz ] && wget https://www.python.org/ftp/python/3.9.10/Python-3.9.10.tar.xz
+


### PR DESCRIPTION
Added Python and OCIO support.
Made version variables for all libraries.
Moved `pyenv`, `pybind11` & `jpegturbo` to use tarballs.

Currently set to python 3.9.10, which is not in line with the latest VFX reference platform. Should be a 3.10.* version.

fmtlib & Tessil still need to be moved to tarballs. Currently downloaded automatically by OIIO.